### PR TITLE
保存画像の名前を修正

### DIFF
--- a/app/src/main/java/com/example/digitalcloset2/components/Camera.kt
+++ b/app/src/main/java/com/example/digitalcloset2/components/Camera.kt
@@ -102,9 +102,13 @@ fun CameraStert(Mainviewmodel: mainviewmodel){
                     cameraController.takePicture(mainExecutorService, object : ImageCapture.OnImageCapturedCallback(){
                         override fun onCaptureSuccess(image: ImageProxy) {
                             val resolver = context.contentResolver
+                            val currentTimeMillis = System.currentTimeMillis()
+                            val displayName = "photo_$currentTimeMillis.jpg"
                             val contentValues = ContentValues().apply {
-                                put(MediaStore.Images.Media.DISPLAY_NAME, "photo.jpg")
+                                put(MediaStore.Images.Media.DISPLAY_NAME, displayName)
                                 put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+                                put(MediaStore.Images.Media.DATE_ADDED, currentTimeMillis / 1000) // 秒単位でのタイムスタンプ
+                                put(MediaStore.Images.Media.DATE_TAKEN, currentTimeMillis)
                                 // 必要に応じて、他のメタデータを追加できます
                             }
                             val imageUri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)


### PR DESCRIPTION
### 画像の名前修正
保存画像が同じ名前だったために、エラーが起こった
**時間を名前に追加して一時的に解決した**